### PR TITLE
export `t1ha0_resolve` when `t1ha0_funcptr` not available

### DIFF
--- a/src/t1ha0.c
+++ b/src/t1ha0.c
@@ -387,7 +387,6 @@ static uint64_t x86_cpu_features(void) {
 }
 #endif /* T1HA0_AESNI_AVAILABLE && __ia32__ */
 
-static
 #if __GNUC_PREREQ(4, 0) || __has_attribute(used)
     __attribute__((used))
 #endif

--- a/t1ha.h
+++ b/t1ha.h
@@ -558,7 +558,7 @@ uint64_t t1ha0_ia32aes_avx2(const void *data, size_t length, uint64_t seed);
 #if T1HA0_RUNTIME_SELECT
 #if T1HA_USE_INDIRECT_FUNCTIONS
 T1HA_API uint64_t t1ha0(const void *data, size_t length, uint64_t seed);
-#else
+#elif __GNUC_PREREQ(4, 0) || __has_attribute(constructor)
 /* Otherwise function pointer will be used.
  * Unfortunately this may cause some overhead calling. */
 T1HA_API extern uint64_t (*t1ha0_funcptr)(const void *data, size_t length,
@@ -567,6 +567,8 @@ static __force_inline uint64_t t1ha0(const void *data, size_t length,
                                      uint64_t seed) {
   return t1ha0_funcptr(data, length, seed);
 }
+#else /* T1HA_USE_INDIRECT_FUNCTIONS */
+T1HA_API extern uint64_t (*t1ha0_resolve(void))(const void *, size_t, uint64_t);
 #endif /* T1HA_USE_INDIRECT_FUNCTIONS */
 
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
When compatibility issue occurred, we can use `t1ha0_resolve` to solve the function pointer instead of `Symbol not found: _t1ha0_funcptr`.  flier/pyfasthash#25

```c++
template <>
const t1ha0_t::hash_value_t t1ha0_t::operator()(void *buf, size_t len, t1ha0_t::seed_value_t seed) const
{
    static auto t1ha0_funcptr = t1ha0_resolve();

    return t1ha0_funcptr(buf, len, seed);
}
```