### PR TITLE
Fixed minor compile issues on FreeBSD12.1/i386

### DIFF
--- a/tests/mera.c
+++ b/tests/mera.c
@@ -26,6 +26,22 @@
 #define NOMINMAX
 #endif
 
+#ifndef _ISOC99_SOURCE
+#define _ISOC99_SOURCE 1
+#endif
+
+#ifndef _ISOC11_SOURCE
+#define _ISOC11_SOURCE 1
+#endif
+
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
@@ -41,26 +57,6 @@
 #ifndef _REENTRANT
 #define _REENTRANT 1
 #endif
-
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) ||     \
-    defined(__BSD__) || defined(__NETBSD__) || defined(__bsdi__) ||            \
-    defined(__DragonFly__)
-#include </usr/include/sys/cdefs.h>
-#else /* BSD */
-
-#ifndef _ISOC99_SOURCE
-#define _ISOC99_SOURCE 1
-#endif
-
-#ifndef _ISOC11_SOURCE
-#define _ISOC11_SOURCE 1
-#endif
-
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
-#endif
-
-#endif /* !BSD */
 
 #if defined(_MSC_VER)
 #pragma warning(disable : 4711) /* function 'xyz' selected for                 \
@@ -85,6 +81,11 @@
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #endif /* Linux */
+
+#if defined(__FreeBSD__)
+#include <unistd.h>
+#include <sys/time.h>
+#endif /* FreeBSD */
 
 #if defined(EMSCRIPTEN)
 #include <emscripten.h>
@@ -252,6 +253,9 @@ static int do_probe(unsigned (*start)(timestamp_t *),
   }
 #endif
 
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 46000;
     for (unsigned n = 0; n < 42; ++n) {
       timestamp_t timestamp_start, timestamp_finish;
       unsigned coreid = start(&timestamp_start);
@@ -259,7 +263,7 @@ static int do_probe(unsigned (*start)(timestamp_t *),
     defined(__WINDOWS__)
       Sleep(1);
 #else
-    usleep(42);
+      nanosleep(&ts, 0);
 #endif
       if (coreid != finish(&timestamp_finish))
         continue;


### PR DESCRIPTION
I have fixed with this patch minor compile issues on FreeBSD 12.1/i386.
I am still not able to compile, because of that error I have reported in "Issues":

```
error: inline assembly requires more registers than available at line 1412312
make: *** [Makefile:123: mera.o] Error 1
```

I wasn't able to determine what is this strange error. Probably a clang bug, or something.